### PR TITLE
allow jax-differentiation for linear parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,170 @@
+# Files to ignore
+*.npz
+
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# static files generated from Django application using `collectstatic`
+media
+static

--- a/pybird/bird.py
+++ b/pybird/bird.py
@@ -64,7 +64,7 @@ class Bird(object):
     """
 
     def __init__(self, cosmology=None, with_bias=True, eft_basis='eftoflss', with_stoch=False, with_nnlo_counterterm=False, co=co):
-        
+
         self.co = co
 
         self.with_bias = with_bias
@@ -78,7 +78,7 @@ class Bird(object):
         self.P22 = np.empty(shape=(self.co.N22, self.co.Nk))
         self.P13 = np.empty(shape=(self.co.N13, self.co.Nk))
         self.Ps = np.zeros(shape=(3, self.co.Nl, self.co.Nk)) # 3: linear, 1-loop, NNLO
-        
+
         self.C11 = np.empty(shape=(self.co.Nl, self.co.Ns))
         self.C22l = np.empty(shape=(self.co.Nl, self.co.N22, self.co.Ns))
         self.C13l = np.empty(shape=(self.co.Nl, self.co.N13, self.co.Ns))
@@ -140,17 +140,17 @@ class Bird(object):
             self.bst = np.zeros(shape=(self.co.Nst))
             self.Pstl = np.zeros(shape=(self.co.Nl, self.co.Nst, self.co.Nk))
             self.Pstl[0,0] = self.co.k**0 # / self.co.nd
-            if self.eft_basis in ["eftoflss", "westcoast"]: 
+            if self.eft_basis in ["eftoflss", "westcoast"]:
                 self.Pstl[0,1] = self.co.k**2 # / self.co.km**2 / self.co.nd
                 self.Pstl[1,2] = self.co.k**2 # / self.co.km**2 / self.co.nd
-            elif self.eft_basis == 'eastcoast': 
+            elif self.eft_basis == 'eastcoast':
                 for i in range(self.co.Nl):
                     self.Pstl[i,1] = mu[0][2*i] * self.co.k**2 # / self.co.km**2 / self.co.nd
                     self.Pstl[i,2] = mu[2][2*i] * self.co.k**2 # / self.co.km**2 / self.co.nd
 
         else:
             if self.co.with_cf: self.Cstl = None
-            else: self.Pstl = None 
+            else: self.Pstl = None
 
         if self.with_nnlo_counterterm:
             self.cnnlo = np.zeros(shape=(self.co.Nl))
@@ -159,19 +159,19 @@ class Bird(object):
             self.Pnnlo = np.empty(shape=(self.co.Nk))
             self.Pnnlol = np.empty(shape=(self.co.Nl, self.co.Nnnlo, self.co.Nk))
         else: # this was clashing with redshift_bin: True, because for output: 'bpk', it is the correlation that is first computed, so co.with_cf = True at the instatiation of the bird... need to change that # PZ
-            self.Pnnlol = None 
+            self.Pnnlol = None
             self.Cnnlol = None
             # if self.co.with_cf: self.Cnnlol = None
-            # else: self.Pnnlol = None 
+            # else: self.Pnnlol = None
 
     def setcosmo(self, cosmo):
 
         self.kin = cosmo["kk"]
         self.Pin = cosmo["pk_lin"]
-        try: 
+        try:
             self.Plin = interp1d(self.kin, self.Pin, kind='cubic')
             self.P11 = self.Plin(self.co.k)
-        except: 
+        except:
             self.Plin = None
             self.P11 = None
 
@@ -234,7 +234,7 @@ class Bird(object):
         b2 = bias["b2"]
         b3 = bias["b3"]
         b4 = bias["b4"]
-        if self.eft_basis in ["eftoflss", "westcoast"]: 
+        if self.eft_basis in ["eftoflss", "westcoast"]:
             b5 = bias["cct"] / self.co.km**2
             b6 = bias["cr1"] / self.co.kr**2
             b7 = bias["cr2"] / self.co.kr**2
@@ -244,18 +244,16 @@ class Bird(object):
             ct4 = bias["c4"]
 
         if self.with_stoch:
-            self.bst[0] = bias["ce0"] / self.co.nd
-            self.bst[1] = bias["ce1"] / self.co.km**2 / self.co.nd
-            self.bst[2] = bias["ce2"] / self.co.km**2 / self.co.nd
+            self.bst = np.array([bias["ce0"], bias["ce1"] / self.co.km**2, bias["ce2"] / self.co.km**2]) / self.co.nd
 
         if self.co.halohalo:
-            
+
             if self.with_tidal_alignments: bq = bias["bq"]
 
             if self.with_bias: # evaluation with biases specified
                 for i in range(self.co.Nl):
                     l = 2 * i
-                    if self.with_nnlo_counterterm: 
+                    if self.with_nnlo_counterterm:
                         if self.eft_basis in ["eftoflss", "westcoast"]: self.cnnlo[i] = 0.25 * ( b1**2 * bias["cr4"] * mu[4][l] + b1 * bias["cr6"] * mu[6][l] ) / self.co.kr**4
                         elif self.eft_basis == "eastcoast": self.cnnlo[i] = - bias["ct"] * f**4 * ( b1**2 * mu[4][l] + 2. * b1 * f * mu[6][l] + f**2 * mu[8][l] )  # these are not divided by kr^4 according to eastcoast definition; the prior is adjusted accordingly
                     if self.with_tidal_alignments: self.b11[i] = (b1-bq/3.)**2 * mu[0][l] + 2. * (b1-bq/3.) * (f+bq) * mu[2][l] + (f+bq)**2 * mu[4][l]
@@ -275,7 +273,7 @@ class Bird(object):
                         self.b22[i] = np.array([b1**2 * mu[0][l], b1 * b2 * mu[0][l], b1 * b4 * mu[0][l], b2**2 * mu[0][l], b2 * b4 * mu[0][l], b4**2 * mu[0][l], b1**2 * f * mu[2][l], b1 * b2 * f * mu[2][l], b1 * b4 * f * mu[2][l], b1 * f * mu[2][l], b2 * f * mu[2][l], b4 * f * mu[2][l], b1**2 * f**2 * mu[2][l], b1**2 * f**2 * mu[4][l], b1 * f**2 * mu[2][l], b1 * f**2 * mu[4][l], b2 * f**2 * mu[2][l], b2 * f**2 * mu[4][l], b4 * f**2 * mu[2][l], b4 * f**2 * mu[4][l], f**2 * mu[4][l], b1 * f**3 * mu[4][l], b1 * f**3 * mu[6][l], f**3 * mu[4][l], f**3 * mu[6][l], f**4 * mu[4][l], f**4 * mu[6][l], f**4 * mu[8][l]])
                         self.b13[i] = np.array([b1**2 * mu[0][l], b1 * b3 * mu[0][l], b1**2 * f * mu[2][l], b1 * f * mu[2][l], b3 * f * mu[2][l], b1 * f**2 * mu[2][l], b1 * f**2 * mu[4][l], f**2 * mu[4][l], f**3 * mu[4][l], f**3 * mu[6][l]])
             else: # evaluation with biases unspecified
-                if self.with_nnlo_counterterm: 
+                if self.with_nnlo_counterterm:
                     if self.eft_basis in ["eftoflss", "westcoast"]: self.cnnlo = 0.25 * np.array([b1**2 * bias["cr4"], b1 * bias["cr6"]]) / self.co.kr**4
                     elif self.eft_basis == "eastcoast": self.cnnlo = - bias["ct"] * f**4 * np.array([b1**2, 2. * b1 * f, f**2])   # these are not divided by kr^4 according to eastcoast definition; the prior is adjusted accordingly
                 if self.with_tidal_alignments: self.b11 = np.array([(b1-bq/3.)**2, 2. * (b1-bq/3.) * (f+bq), (f+bq)**2])
@@ -286,9 +284,9 @@ class Bird(object):
                 elif self.co.Nloop == 22: self.bloop = np.array([f**2, f**3, f**4, b1*f, b1*f**2, b1*f**3, b2*f, b2*f**2, b3*f, b4*f, b4*f**2, b1**2, b1**2*f, b1**2*f**2, b1*b2, b1*b2*f, b1*b3, b1*b4, b1*b4*f, b2**2, b2*b4, b4**2])
                 elif self.co.Nloop == 35: self.bloop = np.array([f**2, f**2*G1t, f**2*G1t**2, f**2*Y1, f**2*V12t, f**3, f**3*G1t, f**4, b1*f, b1*f*G1t, b1*f*Y1, b1*f*V12t, b1*f**2, b1*f**2*G1t, b1*f**3, b2*f, b2*f*G1t, b2*f**2, b3*f, b4*f, b4*f*G1t, b4*f**2, b1**2, b1**2*Y1, b1**2*f, b1**2*f*G1t, b1**2*f**2, b1*b2, b1*b2*f, b1*b3, b1*b4, b1*b4*f, b2**2, b2*b4, b4**2])
                 elif self.co.Nloop == self.co.N22+self.co.N13: self.bloop = np.array([
-                    b1**2, b1 * b2, b1 * b4, b2**2, b2 * b4, b4**2, 
-                    b1**2 * f, b1 * b2 * f, b1 * b4 * f, b1 * f, b2 * f, b4 * f, 
-                    b1**2 * f**2, b1**2 *f**2, b1 * f**2, b1 * f**2, b2 * f**2, b2 * f**2, b4 * f**2, b4 * f**2, f**2, 
+                    b1**2, b1 * b2, b1 * b4, b2**2, b2 * b4, b4**2,
+                    b1**2 * f, b1 * b2 * f, b1 * b4 * f, b1 * f, b2 * f, b4 * f,
+                    b1**2 * f**2, b1**2 *f**2, b1 * f**2, b1 * f**2, b2 * f**2, b2 * f**2, b4 * f**2, b4 * f**2, f**2,
                     b1 * f**3, b1 * f**3, f**3, f**3, f**4, f**4, f**4,
                     b1**2, b1 * b3, b1**2 * f, b1 * f, b3 * f, b1 * f**2, b1 * f**2, f**2, f**3, f**3])
                 elif self.co.Nloop == 18: self.bloop = np.array([1., b1, b2, b3, b4, b1 * b1, b1 * b2, b1 * b3, b1 * b4, b2 * b2, b2 * b4, b4 * b4, bq, bq * bq, bq * b1, bq * b2, bq * b3, bq * b4]) # with_tidal_alignements
@@ -298,7 +296,7 @@ class Bird(object):
             d5 = bias["dct"] / self.co.km**2 # matter counterterm
             d6 = bias["dr1"] / self.co.km**2 # matter redshift counterterm 1
             d7 = bias["dr2"] / self.co.km**2 # matter redshift counterterm 2
-            
+
             if self.with_bias:
                 for i in range(self.co.Nl):
                     l = 2 * i
@@ -358,11 +356,11 @@ class Bird(object):
 
     def setfullPs(self):
         """ For option: which='full'. Adds together the linear and the loop parts to get the full power spectrum multipoles """
-        self.fullPs = np.sum(self.Ps, axis=0) 
+        self.fullPs = np.sum(self.Ps, axis=0)
 
     def setfullCf(self):
         """ For option: which='full'. Adds together the linear and the loop parts to get the full correlation function multipoles """
-        self.fullCf = np.sum(self.Cf, axis=0) 
+        self.fullCf = np.sum(self.Cf, axis=0)
 
     def setPsCfl(self):
         """ For option: which='all'. Creates multipoles for each term weighted accordingly """
@@ -553,7 +551,7 @@ class Bird(object):
                     self.Ploopl[:, 0] = self.P22l[:, 20] + self.P13l[:, 7]   # *f^2
                     self.Ploopl[:, 1] = self.P22l[:, 23] + self.P22l[:, 24] + self.P13l[:, 8] + self.P13l[:, 9]   # *f^3
                     self.Ploopl[:, 2] = self.P22l[:, 25] + self.P22l[:, 26] + self.P22l[:, 27]   # *f^4
-                    self.Ploopl[:, 3] = self.P22l[:, 9] + self.P13l[:, 3]  # *b1*f 
+                    self.Ploopl[:, 3] = self.P22l[:, 9] + self.P13l[:, 3]  # *b1*f
                     self.Ploopl[:, 4] = self.P22l[:, 14] + self.P22l[:, 15] + self.P13l[:, 5] + self.P13l[:, 6]   # *b1*f^2
                     self.Ploopl[:, 5] = self.P22l[:, 21] + self.P22l[:, 22]   # *b1*f^3
                     self.Ploopl[:, 6] = self.P22l[:, 10]   # *b2*f
@@ -562,7 +560,7 @@ class Bird(object):
                     self.Ploopl[:, 9] = self.P22l[:, 11]   # *b4*f
                     self.Ploopl[:, 10] = self.P22l[:, 18] + self.P22l[:, 19]   # *b4*f^2
                     self.Ploopl[:, 11] = self.P22l[:, 0] + self.P13l[:, 0]   # *b1*b1
-                    self.Ploopl[:, 12] = self.P22l[:, 6] + self.P13l[:, 2]   # *b1*b1*f 
+                    self.Ploopl[:, 12] = self.P22l[:, 6] + self.P13l[:, 2]   # *b1*b1*f
                     self.Ploopl[:, 13] = self.P22l[:, 12] + self.P22l[:, 13]   # *b1*b1*f^2
                     self.Ploopl[:, 14] = self.P22l[:, 1]  # *b1*b2
                     self.Ploopl[:, 15] = self.P22l[:, 7]  # *b1*b2*f
@@ -576,7 +574,7 @@ class Bird(object):
                     self.Cloopl[:, 0] = self.C22l[:, 20] + self.C13l[:, 7]   # *f^2
                     self.Cloopl[:, 1] = self.C22l[:, 23] + self.C22l[:, 24] + self.C13l[:, 8] + self.C13l[:, 9]   # *f^3
                     self.Cloopl[:, 2] = self.C22l[:, 25] + self.C22l[:, 26] + self.C22l[:, 27]   # *f^4
-                    self.Cloopl[:, 3] = self.C22l[:, 9] + self.C13l[:, 3]  # *b1*f 
+                    self.Cloopl[:, 3] = self.C22l[:, 9] + self.C13l[:, 3]  # *b1*f
                     self.Cloopl[:, 4] = self.C22l[:, 14] + self.C22l[:, 15] + self.C13l[:, 5] + self.C13l[:, 6]   # *b1*f^2
                     self.Cloopl[:, 5] = self.C22l[:, 21] + self.C22l[:, 22]   # *b1*f^3
                     self.Cloopl[:, 6] = self.C22l[:, 10]   # *b2*f
@@ -585,7 +583,7 @@ class Bird(object):
                     self.Cloopl[:, 9] = self.C22l[:, 11]   # *b4*f
                     self.Cloopl[:, 10] = self.C22l[:, 18] + self.C22l[:, 19]   # *b4*f^2
                     self.Cloopl[:, 11] = self.C22l[:, 0] + self.C13l[:, 0]   # *b1*b1
-                    self.Cloopl[:, 12] = self.C22l[:, 6] + self.C13l[:, 2]   # *b1*b1*f 
+                    self.Cloopl[:, 12] = self.C22l[:, 6] + self.C13l[:, 2]   # *b1*b1*f
                     self.Cloopl[:, 13] = self.C22l[:, 12] + self.C22l[:, 13]   # *b1*b1*f^2
                     self.Cloopl[:, 14] = self.C22l[:, 1]   # *b1*b2
                     self.Cloopl[:, 15] = self.C22l[:, 7]   # *b1*b2*f
@@ -639,7 +637,7 @@ class Bird(object):
                     self.Cloopl[:, 16] = self.C13l[:, 1] + self.C13l[:, 7] # *bq*b3
                     self.Cloopl[:, 17] = self.C22l[:, 2] + self.C22l[:, 13] # *bq*b4
 
-                if self.co.Nloop == self.co.N22 + self.co.N13: 
+                if self.co.Nloop == self.co.N22 + self.co.N13:
                     self.Ploopl[:, :self.co.N22] = self.P22l
                     self.Ploopl[:, self.co.N22:] = self.P13l
                     self.Cloopl[:, :self.co.N22] = self.C22l
@@ -662,7 +660,7 @@ class Bird(object):
                 self.Cloopl[:, 2] = self.C22l[:, 1] + f1 * self.C22l[:, 4] + f1**2 * self.C22l[:, 9] + f1**2 * self.C22l[:, 10] # *b2
                 self.Cloopl[:, 3] = self.C13l[:, 1] + f1 * self.C13l[:, 3] # *b3
                 self.Cloopl[:, 4] = self.C22l[:, 2] + f1 * self.C22l[:, 5] + f1**2 * self.C22l[:, 11] + f1**2 * self.C22l[:, 12] # *b4
-            
+
             elif self.co.Nloop == 25:
                 pass
 
@@ -694,7 +692,7 @@ class Bird(object):
             An array of 7 EFT parameters: b_1, b_2, b_3, b_4, c_{ct}/k_{nl}^2, c_{r,1}/k_{m}^2, c_{r,2}/k_{m}^2
         """
         self.setBias(bs)
-        self.Ps = np.zeros(shape=(3, self.P11l.shape[0], self.P11l.shape[-1])) # using P11l.shape[0] since it can be either M multipoles or N wedges, and using P11l.shape[-1] since it can be binned or evaluated on the asked output k array
+        self.Ps = [None] * 3
         if "full" in what:
             self.Ps[0] = np.einsum('b,lbx->lx', self.b11, self.P11l)
             self.Ps[1] = np.einsum('b,lbx->lx', self.bloop, self.Ploopl) + np.einsum('b,lbx->lx', self.bct, self.Pctl)
@@ -703,15 +701,18 @@ class Bird(object):
         else:
             if "linear" in what: self.Ps[0] = np.einsum('b,lbx->lx', self.b11, self.P11l)
             if "sptloop" in what:
-                if "sptloop22" in what and self.co.keep_loop_pieces_independent: self.Ps[1] = np.einsum('b,lbx->lx', self.bloop[:self.co.N22], self.Ploopl[:, :self.co.N22]) 
-                elif "sptloop13" in what and self.co.keep_loop_pieces_independent: self.Ps[1] = np.einsum('b,lbx->lx', self.bloop[self.co.N22:], self.Ploopl[:, self.co.N22:]) 
-                else: self.Ps[1] = np.einsum('b,lbx->lx', self.bloop, self.Ploopl) 
+                if "sptloop22" in what and self.co.keep_loop_pieces_independent: self.Ps[1] = np.einsum('b,lbx->lx', self.bloop[:self.co.N22], self.Ploopl[:, :self.co.N22])
+                elif "sptloop13" in what and self.co.keep_loop_pieces_independent: self.Ps[1] = np.einsum('b,lbx->lx', self.bloop[self.co.N22:], self.Ploopl[:, self.co.N22:])
+                else: self.Ps[1] = np.einsum('b,lbx->lx', self.bloop, self.Ploopl)
             if "spt" not in what or "counterterm" in what: self.Ps[1] += np.einsum('b,lbx->lx', self.bct, self.Pctl)
             if "stochastic" in what and self.with_stoch: self.Ps[1] += np.einsum('b,lbx->lx', self.bst, self.Pstl)
             if "nnlo_counterterm" in what and self.with_nnlo_counterterm: self.Ps[2] = np.einsum('b,lbx->lx', self.cnnlo, self.Pnnlol)
-            if "ir_correction" in what: 
+            if "ir_correction" in what:
                 self.Ps[0] = np.einsum('b,lbx->lx', self.b11, self.fullIRPs11)
                 self.Ps[1] = np.einsum('b,lbx->lx', self.bloop, self.fullIRPsloop) + np.einsum('b,lbx->lx', self.bct, self.fullIRPsct)
+        if self.Ps[2] is None:
+            self.Ps[2] = np.zeros_like(self.Ps[0])
+        self.Ps = np.array(self.Ps)
         self.setfullPs()
 
     def setreduceCflb(self, bs, what="full"):
@@ -723,11 +724,14 @@ class Bird(object):
             An array of 7 EFT parameters: b_1, b_2, b_3, b_4, c_{ct}/k_{nl}^2, c_{r,1}/k_{m}^2, c_{r,2}/k_{m}^2
         """
         self.setBias(bs)
-        self.Cf = np.zeros(shape=(3, self.C11l.shape[0], self.C11l.shape[-1]))
+        self.Cf = [None] * 3
         self.Cf[0] = np.einsum('b,lbx->lx', self.b11, self.C11l)
         self.Cf[1] = np.einsum('b,lbx->lx', self.bloop, self.Cloopl) + np.einsum('b,lbx->lx', self.bct, self.Cctl)
         if self.with_stoch: self.Cf[1] += np.einsum('b,lbx->lx', self.bst, self.Cstl)
         if self.with_nnlo_counterterm: self.Cf[2] = np.einsum('b,lbx->lx', self.cnnlo, self.Cnnlol)
+        if self.Cf[2] is None:
+            self.Cf[2] = np.zeros_like(self.Cf[0])
+        self.Cf = np.array(self.Cf)
         self.setfullCf()
 
         self.setreducePslb(bs) # PZ NNLO
@@ -793,10 +797,10 @@ class Bird(object):
             D1 = self.D1 / Dfid
             D2 = self.D2 / Dfid
             Dp2 = D1 * D2
-            Dp22 = Dp2 * Dp2 
-            Dp13 = 0.5 * (D1**3*D2 + D2**3*D1) 
+            Dp22 = Dp2 * Dp2
+            Dp13 = 0.5 * (D1**3*D2 + D2**3*D1)
             tloop = np.concatenate([ self.co.N22*[Dp22], self.co.N13*[Dp13] ])
-            
+
             if self.co.with_cf:
                 self.C11l *= Dp2
                 self.Cctl *= Dp2
@@ -813,7 +817,7 @@ class Bird(object):
             self.setcosmo(cosmo)
             Dp1 = self.D/Dfid
             Dp2 = Dp1**2
-            
+
             if self.co.with_cf:
                 self.C11l *= Dp2
                 self.Cctl *= Dp2
@@ -828,5 +832,3 @@ class Bird(object):
             self.IRPs11 = np.einsum('n,lnk->lnk', Dp2*Dp2n, self.IRPs11)
             self.IRPsct = np.einsum('n,lnk->lnk', Dp2*Dp2n, self.IRPsct)
             self.IRPsloop = np.einsum('n,lmnk->lmnk', Dp2**2*Dp2n, self.IRPsloop)
-        
-

--- a/pybird/correlator.py
+++ b/pybird/correlator.py
@@ -25,7 +25,7 @@ from pybird.fourier import FourierTransform
 # from pybird.resum import Resum
 # ################
 
-class Correlator(object): 
+class Correlator(object):
 
     def __init__(self, config_dict=None, load_engines=True):
 
@@ -37,7 +37,7 @@ class Correlator(object):
                 description="k-array in [h/Mpc] on which pk_lin is evaluated",
                 default=None) ,
             "f": Option("f", float,
-                description="Scale independent growth rate (for RSD). Automatically set to 0 for \'output\': \'m__\'.", 
+                description="Scale independent growth rate (for RSD). Automatically set to 0 for \'output\': \'m__\'.",
                 default=None) ,
             "bias": Option("bias", dict,
                 description="EFT parameters in dictionary to specify as \
@@ -47,57 +47,57 @@ class Correlator(object):
                     if (a): \'b\' in \'output\'; (b): \'multipole\'>=2; (d): \'with_stoch\' is True ",
                 default=None) ,
             "H": Option("H", float,
-                description="Hubble parameter by H_0. To specify if \'with_ap\' is True.", 
+                description="Hubble parameter by H_0. To specify if \'with_ap\' is True.",
                 default=None) ,
             "DA": Option("DA", float,
-                description="Angular distance times H_0. To specify if \'with_ap\' is True.", 
+                description="Angular distance times H_0. To specify if \'with_ap\' is True.",
                 default=None) ,
             "z": Option("z", float,
                 description="Effective redshift(s). To specify if \'with_time\' is False or \'with_exact_time\' is True.",
                 default=None) ,
             "D": Option("D", float,
-                description="Scale independent growth function. To specify if \'with_time\' is False, e.g., \'with_nonequal_time\' or \'with_redshift_bin\' is True.", 
+                description="Scale independent growth function. To specify if \'with_time\' is False, e.g., \'with_nonequal_time\' or \'with_redshift_bin\' is True.",
                 default=None) ,
             "A": Option("A", float,
-                description="Amplitude rescaling, i.e, A = A_s / A_s^\{fid\}. Default: A=1. If \'with_time\' is False, can in some ways be used as a fast parameter.", 
+                description="Amplitude rescaling, i.e, A = A_s / A_s^\{fid\}. Default: A=1. If \'with_time\' is False, can in some ways be used as a fast parameter.",
                 default=None) ,
             "Omega0_m": Option("Omega0_m", float,
-                description="Fractional matter abundance at present time. To specify if \'with_exact_time\' is True.", 
+                description="Fractional matter abundance at present time. To specify if \'with_exact_time\' is True.",
                 default=None) ,
             "w0_fld": Option("w0_fld", float,
-                description="Dark energy equation of state parameter. To specify in presence of dark energy if \'with_exact_time\' is True (otherwise w0 = -1).", 
+                description="Dark energy equation of state parameter. To specify in presence of dark energy if \'with_exact_time\' is True (otherwise w0 = -1).",
                 default=None) ,
             "Dz": Option("Dz", (list, np.ndarray),
-                description="Scale independent growth function over redshift bin. To specify if \'with_redshift_bin\' is True.", 
+                description="Scale independent growth function over redshift bin. To specify if \'with_redshift_bin\' is True.",
                 default=None) ,
             "fz": Option("fz", (list, np.ndarray),
-                description="Scale independent growth rate over redshift bin. To specify if \'with_redshift_bin\' is True.", 
+                description="Scale independent growth rate over redshift bin. To specify if \'with_redshift_bin\' is True.",
                 default=None) ,
             "rz": Option("rz", (list, np.ndarray),
-                description="Comoving distance in [Mpc/h] over redshift bin. To specify if \'with_redshift_bin\' or if \'output\':\'w\'.", 
+                description="Comoving distance in [Mpc/h] over redshift bin. To specify if \'with_redshift_bin\' or if \'output\':\'w\'.",
                 default=None) ,
             "D1": Option("D1", float,
-                description="Scale independent growth function at redshift z1. To specify if \'with_nonequal_time\' is True.", 
+                description="Scale independent growth function at redshift z1. To specify if \'with_nonequal_time\' is True.",
                 default=None) ,
             "D2": Option("D2", float,
-                description="Scale independent growth function at redshift z2. To specify if \'with_nonequal_time\' is True.", 
+                description="Scale independent growth function at redshift z2. To specify if \'with_nonequal_time\' is True.",
                 default=None) ,
             "f1": Option("f1", float,
-                description="Scale independent growth rate at redshift z1. To specify if \'with_nonequal_time\' is True.", 
+                description="Scale independent growth rate at redshift z1. To specify if \'with_nonequal_time\' is True.",
                 default=None) ,
             "f2": Option("f2", float,
-                description="Scale independent growth rate at redshift z2. To specify if \'with_nonequal_time\' is True.", 
+                description="Scale independent growth rate at redshift z2. To specify if \'with_nonequal_time\' is True.",
                 default=None) ,
             "Psmooth": Option("Psmooth", (list, np.ndarray),
-                description="Smooth power spectrum. To specify if \'with_nnlo_counterterm\' is True.", 
+                description="Smooth power spectrum. To specify if \'with_nnlo_counterterm\' is True.",
                 default=None) ,
         }
 
         self.c_catalog = {
-            "output": Option("output", str, ["bPk", "bCf", "mPk", "mCf", "bmPk", "bmCf"], 
-                description="Correlator: biased tracers / matter / biased tracers-matter -- power spectrum / correlation function.", 
+            "output": Option("output", str, ["bPk", "bCf", "mPk", "mCf", "bmPk", "bmCf"],
+                description="Correlator: biased tracers / matter / biased tracers-matter -- power spectrum / correlation function.",
                 default="bPk") ,
-            "multipole": Option("multipole", int, [0, 2, 3], 
+            "multipole": Option("multipole", int, [0, 2, 3],
                 description="Number of multipoles. 0: real space. 2: monopole + quadrupole. 3: monopole + quadrupole + hexadecapole.",
                 default=2) ,
             "z": Option("z", float,
@@ -115,13 +115,13 @@ class Correlator(object):
             "kmax": Option("kmax", float,
                 description="kmax in [h/Mpc] for \'output\': \'_Pk\'",
                 default=0.25) ,
-            "with_bias": Option("with_bias", bool, 
+            "with_bias": Option("with_bias", bool,
                 description="Bias (in)dependent evalution. Automatically set to False for \'with_time\': False.",
                    default=False) ,
             "eft_basis": Option("eft_basis", str,
                 description="Basis of EFT parameters: \'eftoflss\' (default), \'westcoast\', or \'eastcoast\'. See cosmology command \'bias\' for more details.",
                 default="eftoflss") ,
-            "with_stoch": Option("with_stoch", bool, 
+            "with_stoch": Option("with_stoch", bool,
                 description="With stochastic terms.",
                    default=False) ,
             "with_nnlo_counterterm": Option("with_nnlo_counterterm", bool,
@@ -167,10 +167,10 @@ class Correlator(object):
                 description="Apply Alcock Paczynski effect. ",
                 default=False) ,
             "H_fid": Option("H_fid", float,
-                description="Hubble parameter by H_0. To specify if \'with_ap\' is True.", 
+                description="Hubble parameter by H_0. To specify if \'with_ap\' is True.",
                 default=None) ,
             "D_fid": Option("D_fid", float,
-                description="Angular distance times H_0. To specify if \'with_ap\' is True.", 
+                description="Angular distance times H_0. To specify if \'with_ap\' is True.",
                 default=None) ,
             "with_survey_mask": Option("with_survey_mask", bool,
                 description="Apply survey mask. Automatically set to False for \'output\': \'_Cf\'.",
@@ -184,7 +184,7 @@ class Correlator(object):
             "with_fibercol": Option("with_fibercol", bool,
                 description="Apply fiber collision effective window corrections.",
                 default=False) ,
-            "with_wedge": Option("with_wedge", bool, 
+            "with_wedge": Option("with_wedge", bool,
                 description="Rotate multipoles to wedges",
                 default=False) ,
             "wedge_mat_wl": Option("wedge_mat_wl", (list, np.ndarray),
@@ -209,9 +209,9 @@ class Correlator(object):
                 description="keep the loop pieces 13 and 22 independent (mainly for debugging)",
                 default=False) ,
         }
-        
+
         if config_dict is not None: self.set(config_dict, load_engines=load_engines)
-    
+
 
     def info(self, description=True):
 
@@ -233,40 +233,40 @@ class Correlator(object):
                 if description:
                     print ('    - %s' % config.description)
                     print ('    * default: %s' % config.default)
-    
+
     def set(self, config_dict, load_engines=True):
-        
+
         # Reading config provided by user
         self.__read_config(config_dict)
-        
+
         # Setting no-optional config
         self.c["smin"] = 1.
         self.c["smax"] = 1000.
         self.c["kmin"] = 0.001
-        
+
         # Checking for config conflict
         self.__is_config_conflict()
 
         # Setting list of EFT parameters required by the user to provide later
         self.__set_eft_parameters_list()
-        
+
         # Loading PyBird engines
         self.__load_engines(load_engines=load_engines)
 
-    def compute(self, cosmo_dict=None, cosmo_module=None, cosmo_engine=None, correlator_engine=None, do_core=True, do_survey_specific=True): 
+    def compute(self, cosmo_dict=None, cosmo_module=None, cosmo_engine=None, correlator_engine=None, do_core=True, do_survey_specific=True):
 
         if cosmo_dict: cosmo_dict_local = cosmo_dict.copy()
         elif cosmo_module and cosmo_engine: cosmo_dict_local = {}
-        else: raise Exception('provide cosmo_dict or CLASSy engine with cosmo_module=\'class\' ') 
-        
+        else: raise Exception('provide cosmo_dict or CLASSy engine with cosmo_module=\'class\' ')
+
         if cosmo_module: # works only with classy now
             cosmo_dict_class = self.set_cosmo(cosmo_dict, module=cosmo_module, engine=cosmo_engine)
             cosmo_dict_local.update(cosmo_dict_class)
-        
+
         self.__read_cosmo(cosmo_dict_local)
         self.__is_cosmo_conflict()
 
-        if do_core: 
+        if do_core:
             self.bird = Bird(self.cosmo, with_bias=self.c["with_bias"], eft_basis=self.c["eft_basis"], with_stoch=self.c["with_stoch"], with_nnlo_counterterm=self.c["with_nnlo_counterterm"], co=self.co)
             if self.c["with_nnlo_counterterm"]: # we use smooth power spectrum since we don't want spurious BAO signals
                 ilogPsmooth = interp1d(np.log(self.bird.kin), np.log(self.cosmo["Psmooth"]), fill_value='extrapolate')
@@ -276,34 +276,34 @@ class Correlator(object):
             elif correlator_engine: correlator_engine.nonlinear.PsCf(self.bird, c_alpha) # PZemu
             if self.c["with_bias"]: self.bird.setPsCf(self.bias)
             else: self.bird.setPsCfl()
-            if self.c["with_resum"]: 
+            if self.c["with_resum"]:
                 if not correlator_engine: self.resum.PsCf(self.bird, makeIR=True, makeQ=False, setIR=False, setPs=False, setCf=False) # compute IR-correction pieces
                 elif correlator_engine: correlator_engine.resum.PsCf(self.bird, c_alpha) # PZemu
 
-        if do_survey_specific: 
-            if not self.c["with_time"]: self.bird.settime(self.cosmo, co=self.co) 
-            if self.c["with_resum"]: self.resum.PsCf(self.bird, makeIR=False, makeQ=True, setIR=True, setPs=True, setCf=self.c["with_cf"]) 
+        if do_survey_specific:
+            if not self.c["with_time"]: self.bird.settime(self.cosmo, co=self.co)
+            if self.c["with_resum"]: self.resum.PsCf(self.bird, makeIR=False, makeQ=True, setIR=True, setPs=True, setCf=self.c["with_cf"])
             if self.c["with_redshift_bin"]: self.projection.redshift(self.bird, self.cosmo["rz"], self.cosmo["Dz"], self.cosmo["fz"], pk=self.c["output"])
             if self.c["with_ap"]: self.projection.AP(self.bird)
             if self.c["with_fibercol"]: self.projection.fibcolWindow(self.bird)
             if self.c["with_survey_mask"]: self.projection.Window(self.bird)
-            elif self.c["with_binning"]: self.projection.xbinning(self.bird) # no binning if 'with_survey_mask' since the mask should account for it. 
+            elif self.c["with_binning"]: self.projection.xbinning(self.bird) # no binning if 'with_survey_mask' since the mask should account for it.
             elif self.c["xdata"] is not None: self.projection.xdata(self.bird)
             if self.c["with_wedge"]: self.projection.Wedges(self.bird)
 
     def get(self, bias=None, what="full"):
 
-        if not self.c["with_bias"]: 
+        if not self.c["with_bias"]:
             self.__is_bias_conflict(bias)
             if "Pk" in self.c["output"]: self.bird.setreducePslb(self.bias, what=what)
             elif "Cf" in self.c["output"]: self.bird.setreduceCflb(self.bias, what=what)
         if "Pk" in self.c["output"]: return self.bird.fullPs
-        elif "Cf" in self.c["output"]: return self.bird.fullCf  
+        elif "Cf" in self.c["output"]: return self.bird.fullCf
 
     def getmarg(self, bias, marg_gauss_eft_parameters_list):
 
         for p in marg_gauss_eft_parameters_list:
-            if p not in self.gauss_eft_parameters_list: 
+            if p not in self.gauss_eft_parameters_list:
                 raise Exception("The parameter %s specified in getmarg() is not an available Gaussian EFT parameter to marginalize. Check your options. " % p)
 
         def marg(loopl, ctl, b1, f, stl=None, nnlol=None, bq=0):
@@ -312,26 +312,26 @@ class Correlator(object):
             loop = np.swapaxes(loopl, axis1=0, axis2=1).reshape(loopl.shape[1],-1)
             ct = np.swapaxes(ctl, axis1=0, axis2=1).reshape(ctl.shape[1],-1)
             if stl is not None: st = np.swapaxes(stl, axis1=0, axis2=1).reshape(stl.shape[1],-1)
-            if nnlol is not None: nnlo = np.swapaxes(nnlol, axis1=0, axis2=1).reshape(nnlol.shape[1],-1) 
+            if nnlol is not None: nnlo = np.swapaxes(nnlol, axis1=0, axis2=1).reshape(nnlol.shape[1],-1)
 
             pg = np.empty(shape=(len(marg_gauss_eft_parameters_list), loop.shape[1]))
             for i, p in enumerate(marg_gauss_eft_parameters_list):
-                if p in ['b3', 'bGamma3']: 
+                if p in ['b3', 'bGamma3']:
                     if self.co.Nloop == 12: pg[i] = loop[3] + b1 * loop[7]                          # config["with_time"] = True
                     elif self.co.Nloop == 18: pg[i] = loop[3] + b1 * loop[7] + bq * loop[16]        # config["with_time"] = True, config["with_tidal_alignments"] = True
                     elif self.co.Nloop == 22: pg[i] = f * loop[8] + b1 * loop[16]                   # config["with_time"] = False, config["with_exact_time"] = False
                     elif self.co.Nloop == 35: pg[i] = f * loop[18] + b1 * loop[29]                  # config["with_time"] = False, config["with_exact_time"] = True
                     if p == 'bGamma3': pg[i] *= 6. # b3 = b1 + 15. * bG2 + 6. * bGamma3 : config["eft_basis"] = 'eastcoast'
                 # counterterm : config["eft_basis"] = 'eftoflss' or 'westcoast'
-                elif p == 'cct': pg[i] = 2 * (f * ct[0+3] + b1 * ct[0]) / self.c["km"]**2 # ~ 2 (b1 + f * mu^2) k^2/km^2 pk_lin 
-                elif p == 'cr1': pg[i] = 2 * (f * ct[1+3] + b1 * ct[1]) / self.c["kr"]**2 # ~ 2 (b1 mu^2 + f * mu^4) k^2/kr^2 pk_lin 
-                elif p == 'cr2': pg[i] = 2 * (f * ct[2+3] + b1 * ct[2]) / self.c["kr"]**2 # ~ 2 (b1 mu^4 + f * mu^6) k^2/kr^2 pk_lin 
+                elif p == 'cct': pg[i] = 2 * (f * ct[0+3] + b1 * ct[0]) / self.c["km"]**2 # ~ 2 (b1 + f * mu^2) k^2/km^2 pk_lin
+                elif p == 'cr1': pg[i] = 2 * (f * ct[1+3] + b1 * ct[1]) / self.c["kr"]**2 # ~ 2 (b1 mu^2 + f * mu^4) k^2/kr^2 pk_lin
+                elif p == 'cr2': pg[i] = 2 * (f * ct[2+3] + b1 * ct[2]) / self.c["kr"]**2 # ~ 2 (b1 mu^4 + f * mu^6) k^2/kr^2 pk_lin
                 # counterterm : config["eft_basis"] = 'eastcoast'                       # (2.15) and (2.23) of 2004.10607
                 elif p in ['c0', 'c2', 'c4']:
-                    ct0, ct2, ct4 = - 2 * ct[0], - 2 * f * ct[1], - 2 * f**2 * ct[2]    # - 2 ct0 k^2 pk_lin , - 2 ct2 f mu^2 k^2 pk_lin , - 2 ct4 f^2 mu^4 k^2 pk_lin 
-                    if p == 'c0':   pg[i] = ct0                                           
-                    elif p == 'c2': pg[i] = - f/3. * ct0 + ct2                        
-                    elif p == 'c4': pg[i] = 3/35. * f**2 * ct0 - 6/7. * f * ct2 + ct4                                      
+                    ct0, ct2, ct4 = - 2 * ct[0], - 2 * f * ct[1], - 2 * f**2 * ct[2]    # - 2 ct0 k^2 pk_lin , - 2 ct2 f mu^2 k^2 pk_lin , - 2 ct4 f^2 mu^4 k^2 pk_lin
+                    if p == 'c0':   pg[i] = ct0
+                    elif p == 'c2': pg[i] = - f/3. * ct0 + ct2
+                    elif p == 'c4': pg[i] = 3/35. * f**2 * ct0 - 6/7. * f * ct2 + ct4
                 # stochastic term
                 elif p == 'ce0': pg[i] = st[0] / self.c["nd"] # k^0 / nd mono
                 elif p == 'ce1': pg[i] = st[1] / self.c["km"]**2 / self.c["nd"] # k^2 / km^2 / nd mono
@@ -356,20 +356,19 @@ class Correlator(object):
     def __load_engines(self, load_engines=True):
 
         self.co = Common(Nl=self.c["multipole"], kmax=self.c["kmax"], km=self.c["km"], kr=self.c["kr"], nd=self.c["nd"], eft_basis=self.c["eft_basis"],
-            halohalo=self.c["halohalo"], with_cf=self.c["with_cf"], with_time=self.c["with_time"], optiresum=self.c["optiresum"], 
-            exact_time=self.c["with_exact_time"], quintessence=self.c["with_quintessence"], 
+            halohalo=self.c["halohalo"], with_cf=self.c["with_cf"], with_time=self.c["with_time"], optiresum=self.c["optiresum"],
+            exact_time=self.c["with_exact_time"], quintessence=self.c["with_quintessence"],
             with_tidal_alignments=self.c["with_tidal_alignments"], nonequaltime=self.c["with_common_nonequal_time"], keep_loop_pieces_independent=self.c["keep_loop_pieces_independent"])
-        
         if load_engines:
             self.nonlinear = NonLinear(load=True, save=True, fftbias=self.c["fftbias"], co=self.co)
             self.resum = Resum(co=self.co)
-            self.projection = Projection(self.c["xdata"], 
+            self.projection = Projection(self.c["xdata"],
                 with_ap=self.c["with_ap"], H_fid=self.c["H_fid"], D_fid=self.c["D_fid"],
-                with_survey_mask=self.c["with_survey_mask"], survey_mask_arr_p=self.c["survey_mask_arr_p"], survey_mask_mat_kp=self.c["survey_mask_mat_kp"], 
-                with_binning=self.c["with_binning"], binsize=self.c["binsize"], 
-                fibcol=self.c["with_fibercol"], 
+                with_survey_mask=self.c["with_survey_mask"], survey_mask_arr_p=self.c["survey_mask_arr_p"], survey_mask_mat_kp=self.c["survey_mask_mat_kp"],
+                with_binning=self.c["with_binning"], binsize=self.c["binsize"],
+                fibcol=self.c["with_fibercol"],
                 with_wedge=self.c["with_wedge"], wedge_mat_wl=self.c["wedge_mat_wl"],
-                with_redshift_bin=self.c["with_redshift_bin"], redshift_bin_zz=self.c["redshift_bin_zz"], redshift_bin_nz=self.c["redshift_bin_nz"], 
+                with_redshift_bin=self.c["with_redshift_bin"], redshift_bin_zz=self.c["redshift_bin_zz"], redshift_bin_nz=self.c["redshift_bin_nz"],
                 co=self.co)
             if self.c["with_nnlo_counterterm"]: self.nnlo_counterterm = NNLO_counterterm(co=self.co)
 
@@ -381,7 +380,7 @@ class Correlator(object):
                     if cosmo_key is name:
                         cosmo.check(cosmo_key, cosmo_dict[cosmo_key])
 
-        # Setting unspecified configs to default value 
+        # Setting unspecified configs to default value
         for (name, cosmo) in zip(self.cosmo_catalog, self.cosmo_catalog.values()):
             if cosmo.value is None: cosmo.value = cosmo.default
 
@@ -394,7 +393,7 @@ class Correlator(object):
 
         if self.cosmo["kk"] is None or self.cosmo["pk_lin"] is None:
             raise Exception("Please provide a linear matter power spectrum \'pk_lin\' and the corresponding \'kk\'. ")
-        
+
         if len(self.cosmo["kk"]) != len(self.cosmo["pk_lin"]):
             raise Exception("Please provide a linear matter power spectrum \'pk_lin\' and the corresponding \'kk\' of same length.")
 
@@ -402,9 +401,9 @@ class Correlator(object):
             raise Exception("Please provide a linear matter spectrum \'pk_lin\' and the corresponding \'kk\' with min(kk) < 1e-4 and max(kk) > 1.")
 
         if self.c["multipole"] == 0: self.cosmo["f"] = 0.
-        elif not self.c["with_redshift_bin"] and self.cosmo["f"] is None: 
+        elif not self.c["with_redshift_bin"] and self.cosmo["f"] is None:
             raise Exception("Please specify the growth rate \'f\'.")
-        elif self.c["with_redshift_bin"] and (self.cosmo["Dz"] is None or self.cosmo["fz"] is None): 
+        elif self.c["with_redshift_bin"] and (self.cosmo["Dz"] is None or self.cosmo["fz"] is None):
             raise Exception("You asked to account the galaxy counts distribution. Please specify \'Dz\' and \'fz\'. ")
 
         if not self.c["with_time"] and self.cosmo["D"] is None:
@@ -418,21 +417,21 @@ class Correlator(object):
 
         if not self.c["with_time"] and self.cosmo["A"]: self.cosmo["D"] *= self.cosmo["A"]**.5
 
-    def __is_bias_conflict(self, bias=None): 
-        if bias is not None: self.cosmo["bias"] = bias 
-        if self.cosmo["bias"] is None: raise Exception("Please specify \'bias\'. ") 
-        if isinstance(self.cosmo["bias"], (list, np.ndarray)): self.cosmo["bias"] = self.cosmo["bias"][0] 
-        if not isinstance(self.cosmo["bias"], dict): raise Exception("Please specify bias in a dict. ") 
-        
+    def __is_bias_conflict(self, bias=None):
+        if bias is not None: self.cosmo["bias"] = bias
+        if self.cosmo["bias"] is None: raise Exception("Please specify \'bias\'. ")
+        if isinstance(self.cosmo["bias"], (list, np.ndarray)): self.cosmo["bias"] = self.cosmo["bias"][0]
+        if not isinstance(self.cosmo["bias"], dict): raise Exception("Please specify bias in a dict. ")
+
         for p in self.eft_parameters_list:
-            if p not in self.cosmo["bias"]: 
+            if p not in self.cosmo["bias"]:
                 raise Exception ("%s not found, please provide (given command \'eft_basis\': \'%s\') %s" % (p, self.c["eft_basis"], self.eft_parameters_list))
 
         # PZ: here I should auto-fill the EFT parameters for all output options!!!
-        
+
         self.bias = self.cosmo["bias"]
 
-        if "b" in self.c["output"]: 
+        if "b" in self.c["output"]:
             if "westcoast" in self.c["eft_basis"]:
                 self.bias["b2"] = 2.**-.5 * (self.bias["c2"] + self.bias["c4"])
                 self.bias["b4"] = 2.**-.5 * (self.bias["c2"] - self.bias["c4"])
@@ -445,18 +444,18 @@ class Correlator(object):
 
     def __set_eft_parameters_list(self):
 
-        if self.c["eft_basis"] in ["eftoflss", "westcoast"]: 
+        if self.c["eft_basis"] in ["eftoflss", "westcoast"]:
             self.gauss_eft_parameters_list = ['cct']
             if self.c["multipole"] >= 2: self.gauss_eft_parameters_list.extend(['cr1', 'cr2'])
-        elif self.c["eft_basis"] == "eastcoast": 
+        elif self.c["eft_basis"] == "eastcoast":
             self.gauss_eft_parameters_list = ['c0']
             if self.c["multipole"] >= 2: self.gauss_eft_parameters_list.extend(['c2', 'c4'])
         if self.c["with_stoch"]: self.gauss_eft_parameters_list.extend(['ce0', 'ce1', 'ce2'])
-        if self.c["with_nnlo_counterterm"]: 
+        if self.c["with_nnlo_counterterm"]:
             if self.c["eft_basis"] in ["eftoflss", "westcoast"]: self.gauss_eft_parameters_list.extend(['cr4', 'cr6'])
             elif self.c["eft_basis"] == "eastcoast": self.gauss_eft_parameters_list.append('ct')
         self.eft_parameters_list = deepcopy(self.gauss_eft_parameters_list)
-        if "b" in self.c["output"]: 
+        if "b" in self.c["output"]:
             if self.c["eft_basis"] in ["eftoflss", "westcoast"]: self.gauss_eft_parameters_list.append('b3')
             elif self.c["eft_basis"] == "eastcoast": self.gauss_eft_parameters_list.append('bGamma3')
             if self.c["eft_basis"] == "eftoflss": self.eft_parameters_list.extend(['b1', 'b2', 'b3', 'b4'])
@@ -474,26 +473,26 @@ class Correlator(object):
                     config.check(config_key, config_dict[config_key])
                     is_config = True
             ### v1.2: we'll activate this later
-            # if not is_config: 
+            # if not is_config:
             #     raise Exception("%s is not an available configuration option. Please check correlator.info() for help. " % config_key)
-            
-        # Setting unspecified configs to default value 
+
+        # Setting unspecified configs to default value
         for (name, config) in zip(self.c_catalog, self.c_catalog.values()):
             if config.value is None: config.value = config.default
 
         # Translating the catalog to a dict
         self.c = translate_catalog_to_dict(self.c_catalog)
-        
+
         self.c["accboost"] = float(self.c["accboost"])
 
     def __is_config_conflict(self):
 
         if "Cf" in self.c["output"]: self.c.update({"with_cf": True, "with_survey_mask": False, "with_stoch": False})
         else: self.c["with_cf"] = False
-        
+
         if "bm" in self.c["output"]: self.c["halohalo"] = False
         else: self.c["halohalo"] = True
-        
+
         if self.c["with_quintessence"]: self.c["with_exact_time"] = True
 
         self.c["with_common_nonequal_time"] = False # this is to pass for the common Class to setup the numbers of loops (22 and 13 gathered by default)
@@ -503,7 +502,7 @@ class Correlator(object):
 
         if self.c["with_ap"] and (self.c["H_fid"] is None or self.c["D_fid"] is None):
                 raise Exception("You asked to apply the AP effect. Please specify \'H_fid\' and \'D_fid\'. ")
-        
+
         if self.c["with_survey_mask"] and (self.c["survey_mask_arr_p"] is None or self.c["survey_mask_mat_kp"] is None): raise Exception("Survey mask: on. Please specify \'survey_mask_arr_p\' and \'survey_mask_mat_kp\'. ")
         if self.c["with_binning"] and self.c["binsize"] is None: raise Exception("Binning: on. Please provide \'binsize\'.")
         if self.c["with_redshift_bin"]:
@@ -514,12 +513,12 @@ class Correlator(object):
     def set_cosmo(self, cosmo_dict, module='class', engine=None):
 
         cosmo = {}
-        
+
         if module == 'class':
 
-            log10kmax = 0 
+            log10kmax = 0
             if self.c["with_nnlo_counterterm"]: log10kmax = 1 # slower, but required for the wiggle-no-wiggle split scheme
-            
+
             if not engine:
                 from classy import Class
                 cosmo_dict_local = cosmo_dict.copy()
@@ -537,13 +536,13 @@ class Correlator(object):
             cosmo["pk_lin"] = np.array([M.pk_lin(k*M.h(), self.c["z"])*M.h()**3 for k in cosmo["kk"]]) # P(k) in (Mpc/h)**3
 
             if self.c["multipole"] > 0: cosmo["f"] = M.scale_independent_growth_factor_f(self.c["z"])
-            if not self.c["with_time"]: cosmo["D"] = M.scale_independent_growth_factor(self.c["z"]) 
+            if not self.c["with_time"]: cosmo["D"] = M.scale_independent_growth_factor(self.c["z"])
             if self.c["with_nonequal_time"]:
-                cosmo["D1"] = M.scale_independent_growth_factor(self.c["z1"]) 
-                cosmo["D2"] = M.scale_independent_growth_factor(self.c["z2"]) 
-                cosmo["f1"] = M.scale_independent_growth_factor_f(self.c["z1"]) 
-                cosmo["f2"] = M.scale_independent_growth_factor_f(self.c["z2"]) 
-            if self.c["with_exact_time"] or self.c["with_quintessence"]: 
+                cosmo["D1"] = M.scale_independent_growth_factor(self.c["z1"])
+                cosmo["D2"] = M.scale_independent_growth_factor(self.c["z2"])
+                cosmo["f1"] = M.scale_independent_growth_factor_f(self.c["z1"])
+                cosmo["f2"] = M.scale_independent_growth_factor_f(self.c["z2"])
+            if self.c["with_exact_time"] or self.c["with_quintessence"]:
                 cosmo["z"] = self.c["z"]
                 cosmo["Omega0_m"] = M.Omega0_m()
                 if "w0_fld" in cosmo_dict: cosmo["w0_fld"] = cosmo_dict["w0_fld"]
@@ -556,8 +555,8 @@ class Correlator(object):
                 cosmo["fz"] = np.array([M.scale_independent_growth_factor_f(z) for z in self.c["redshift_bin_zz"]])
                 cosmo["rz"] = np.array([comoving_distance(z) for z in self.c["redshift_bin_zz"]])
 
-            if self.c["with_quintessence"]: 
-                # starting deep inside matter domination and evolving to the total adiabatic linear power spectrum. 
+            if self.c["with_quintessence"]:
+                # starting deep inside matter domination and evolving to the total adiabatic linear power spectrum.
                 # This does not work in the general case, e.g. with massive neutrinos (okish for minimal mass though)
                 # This does not work for 'with_redshift_bin': True. # eventually to code up
                 zm = 5. # z in matter domination
@@ -596,7 +595,7 @@ class Correlator(object):
 
             return cosmo
 
-class BiasCorrelator(Correlator): 
+class BiasCorrelator(Correlator):
     '''
     Class to load pre-computed correlator
     '''
@@ -632,9 +631,9 @@ class Option(object):
             if self.list is None: is_config = True
             elif isinstance(config_value, str):
                 if any(config_value in o for o in self.list): is_config = True
-            elif isinstance(config_value, (int, float, bool)): 
+            elif isinstance(config_value, (int, float, bool)):
                 if any(config_value == o for o in self.list): is_config = True
-        if is_config: 
+        if is_config:
             self.value = config_value
         else: self.error()
         return is_config
@@ -646,7 +645,3 @@ class Option(object):
         else:
             try: raise Exception("Input error in \'%s\'; input configs: %s. Check Correlator.info() in any doubt." % (self.name, self.list))
             except Exception as e: print(e)
-
-
-
-

--- a/pybird/fftlog.py
+++ b/pybird/fftlog.py
@@ -89,15 +89,19 @@ class FFTLog(object):
         tmp = np.empty(int(self.Nmax / 2 + 1), dtype=complex)
         Coef = np.empty(self.Nmax + 1, dtype=complex)
 
-        if extrap is 'extrap':
+        if extrap == 'extrap':
+            nslow, Aslow = 0, 0
             if xin[0] > self.x[0]:
                 #print ('low extrapolation')
-                nslow = (log(f[1]) - log(f[0])) / (log(xin[1]) - log(xin[0]))
-                Aslow = f[0] / xin[0]**nslow
+                if f[0] * f[1] != 0.:
+                    nslow = (log(f[1]) - log(f[0])) / (log(xin[1]) - log(xin[0]))
+                    Aslow = f[0] / xin[0]**nslow
+            nshigh, Ashigh = 0, 0
             if xin[-1] < self.x[-1]:
                 #print ('high extrapolation')
-                nshigh = (log(f[-1]) - log(f[-2])) / (log(xin[-1]) - log(xin[-2]))
-                Ashigh = f[-1] / xin[-1]**nshigh
+                if f[-1] * f[-2] != 0.:
+                    nshigh = (log(f[-1]) - log(f[-2])) / (log(xin[-1]) - log(xin[-2]))
+                    Ashigh = f[-1] / xin[-1]**nshigh
 
             for i in range(self.Nmax):
                 if xin[0] > self.x[i]:
@@ -107,7 +111,7 @@ class FFTLog(object):
                 else:
                     fx[i] = interpfunc(self.x[i]) * exp(-self.bias * i * self.dx)
 
-        elif extrap is'padding':
+        elif extrap == 'padding':
             for i in range(self.Nmax):
                 if xin[0] > self.x[i]:
                     fx[i] = 0.

--- a/pybird/resum.py
+++ b/pybird/resum.py
@@ -9,7 +9,7 @@ from pybird.resumfactor import Qa, Qawithhex, Qawithhex20
 
 class Resum(object):
     """
-    given a Bird() object, performs the IR-resummation of the power spectrum. 
+    given a Bird() object, performs the IR-resummation of the power spectrum.
     There are two options:
     1.  fullresum: the FFTLog's are performed on the full integrands from s = .1 to s = 10000. in (Mpc/h) (default)
     2. 'optiresum: the FFTLog's are performed only on the BAO peak that is extracted by removing the smooth part of the correlation function. What is left is then padded with zeros and the FFTLog's run from s = .1 to s = 1000. in (Mpc/h).
@@ -60,7 +60,7 @@ class Resum(object):
     XM : ndarray
         spherical Bessel transform matrices to evaluate the IR-filters X and Y
     XsPow : ndarray
-        s's to the powers on which to perform the FFTLog to evaluate the IR-filters X and Y    
+        s's to the powers on which to perform the FFTLog to evaluate the IR-filters X and Y
     """
 
     def __init__(self, LambdaIR=.2, NFFT=192, co=co):
@@ -86,7 +86,7 @@ class Resum(object):
         self.Nlow = np.where(self.klow <= self.co.k)[0][0]
         k2pi = np.array([self.kr**(2*(p+1)) for p in range(self.co.NIR)])
         self.k2p = np.concatenate((k2pi, k2pi))
-        
+
         self.fftsettings = dict(Nmax=NFFT, xmin=.1, xmax=10000., bias=-0.6)
         self.fft = FFTLog(**self.fftsettings)
         self.setM()
@@ -147,7 +147,7 @@ class Resum(object):
 
     def setkPow(self):
         """ Multiply the coefficients with the k's to the powers of the FFTLog to evaluate the IR-corrections. """
-        self.kPow = exp(np.einsum('n,s->ns', -self.fft.Pow - 3., log(self.kr))) 
+        self.kPow = exp(np.einsum('n,s->ns', -self.fft.Pow - 3., log(self.kr)))
 
     def setM(self, Nl=3):
         """ Compute the matrices to evaluate the IR-corrections. Called at instantiation. """
@@ -161,8 +161,8 @@ class Resum(object):
         return np.real(np.einsum('nk,ln->lk', CoefkPow, self.M[:self.co.Na]))
 
     def extractBAO(self, cf):
-        """ Given a correlation function cf, 
-            - if fullresum, return cf 
+        """ Given a correlation function cf,
+            - if fullresum, return cf
             - if optiresum, extract the BAO peak """
         if self.co.optiresum:
             cfnobao = np.concatenate([cf[..., :self.idlow], cf[..., self.idhigh:]], axis=-1)
@@ -204,7 +204,7 @@ class Resum(object):
 
     def Ps2Cf(self, P, l=0):
         Coef = self.Cfft.Coef(self.co.k, P * self.dampPs[l], extrap='padding', window=None)
-        CoefsPow = np.einsum('n,ns->ns', Coef, self.sPow) 
+        CoefsPow = np.einsum('n,ns->ns', Coef, self.sPow)
         return np.real(np.einsum('ns,n->s', CoefsPow, self.Ml[l])) * self.dampCf
 
     def IRCf(self, bird, window=None):
@@ -228,9 +228,9 @@ class Resum(object):
     def PsCf(self, bird, makeIR=True, makeQ=True, setIR=True, setPs=True, setCf=True, window=None):
 
         self.Ps(bird, makeIR=makeIR, makeQ=makeQ, setIR=setIR, setPs=setPs, window=window)
-        if setCf: 
-            self.IRCf(bird, window=window) 
-            bird.setresumCf() 
+        if setCf:
+            self.IRCf(bird, window=window)
+            bird.setresumCf()
 
     def Ps(self, bird, makeIR=True, makeQ=True, setIR=True, setPs=True, window=None):
 
@@ -247,7 +247,7 @@ class Resum(object):
         if bird.with_bias:
             for a, cf in enumerate(self.extractBAO(bird.Cf[:2])): # linear, loop (but not NNLO)
                 for l, cl in enumerate(cf):
-                    for j, xy in enumerate(XpYp): 
+                    for j, xy in enumerate(XpYp):
                         IRcorrUnsorted = np.real((-1j)**(2*l)) * self.k2p[j] * self.IRn(xy * cl, window=window)
                         for v in range(self.co.Na): bird.IRPs[a, l, j*self.co.Na + v, self.Nlow:] = IRcorrUnsorted[v]
 
@@ -265,4 +265,3 @@ class Resum(object):
                     for j, xy in enumerate(XpYp):
                         IRcorrUnsorted = np.real((-1j)**(2*l)) * self.k2p[j] * self.IRn(xy * cli, window=window)
                         for v in range(self.co.Na): bird.IRPsloop[l, i, j*self.co.Na + v, self.Nlow:] = IRcorrUnsorted[v]
-


### PR DESCRIPTION
For the analytic marginalization, I'm using jax (because it is easier to handle generically). For this, I just have to replace np by jax.numpy in bird (that I can do on-the-fly, no need to change the code), but I also had to make a couple of edits to bird that allows the bias calculation to run both with numpy and jax, as the latter does not support numpy indexing:
- https://github.com/adematti/pybird/blob/3f6f0cd25c55b46c53c03477cdfb6e72f6270eb1/pybird/bird.py#L247 (instead of filling the self.bst array)
- https://github.com/adematti/pybird/blob/3f6f0cd25c55b46c53c03477cdfb6e72f6270eb1/pybird/bird.py#L695 and https://github.com/adematti/pybird/blob/3f6f0cd25c55b46c53c03477cdfb6e72f6270eb1/pybird/bird.py#L727 (instead of creating self.Ps and self.Cf arrays and filling them)
That shouldn't make things any slower with numpy. If you accept this changes, then we will be able to use your main repo for DESI.

In fftlog, I pushed two changes:
- "is" => "==" : https://github.com/adematti/pybird/blob/3f6f0cd25c55b46c53c03477cdfb6e72f6270eb1/pybird/fftlog.py#L92
- https://github.com/adematti/pybird/blob/3f6f0cd25c55b46c53c03477cdfb6e72f6270eb1/pybird/fftlog.py#L103 fails when f[-1] or f[-2] is 0, which can happen at high k (~ 9 h/Mpc) with exponential damping https://github.com/adematti/pybird/blob/3f6f0cd25c55b46c53c03477cdfb6e72f6270eb1/pybird/resum.py#L135
So I just added a check that pads with zero if f[-1] or f[-2] is 0 (same for f[0] and f[1]).

I also added a .gitignore. The rest is just my editor removing trailing spaces (I would advertise VSCode with the Python environment), sorry about that!